### PR TITLE
Update Modbusino.cpp

### DIFF
--- a/Modbusino.cpp
+++ b/Modbusino.cpp
@@ -123,7 +123,7 @@ static void flush(void)
     /* Wait a moment to receive the remaining garbage but avoid getting stuck
      * because the line is saturated */
     while (Serial.available() && i++ < 10) {
-        Serial.flush();
+        Serial.read();
         delay(3);
     }
 }


### PR DESCRIPTION
Address issue #18 raised regarding serial.flush() operation change after Adruino IDE >1.0 

Additional info can be found here:
https://www.baldengineer.com/when-do-you-use-the-arduinos-to-use-serial-flush.html

#18 and karlp fork use slightly different methods, but it looks like the end result is pretty much the same. It looks to me like Master repo  uses very cautious approach, where as the other methods are attempting to use the least wait time during flushing.